### PR TITLE
Build library for iphone is out of date.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -61,11 +61,11 @@ pip install meson
 
 Build the library for iphone:
 
-`./tools/build.sh --iphone static --lto=true --install $PWD/gdk-iphone`
+`./tools/build.sh --iphone static $PWD/gdk-iphone`
 
 or for iphone simulators:
 
-`./tools/build.sh --iphonesim static --lto=true --install $PWD/gdk-iphone`
+`./tools/build.sh --iphonesim static $PWD/gdk-iphone`
 
 
 #### CocoaPods requirements


### PR DESCRIPTION
```
$green_ios % ./tools/build.sh --iphonesim static --lto=true --install $PWD/gdk-iphone
build.sh: unrecognized option `--lto=true'
build.sh: unrecognized option `--install'
```

Not sure if this is expected, but if you remove those two options, at least you get:

```
./tools/build.sh --iphonesim --install static $PWD/gdk-iphone
Done linting! Found 7 violations, 0 serious in 101 files.
```

Doesn't seem like the original options are still relevant; should we maybe use some of these?
```
        --iphone) DEVICE=iphoneos; TARGET=iphone; shift ;;
        --iphonesim) DEVICE=iphonesim; TARGET=iphonesim; shift ;;
        --build-gdk) BUILD_GDK=1; shift ;;
        --sign-and-export) SIGN_EXPORT=1; shift ;;
        --update-cocoapods) UPDATE_COCOAPODS=1; shift ;;
        -- ) break ;;
```