### PR TITLE
CI: Update runner tag k8s-docker to k8s

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ sast:
   before_script:
     - if [[ "$IGNORE_SECURITY" == "true" ]]; then exit 0; fi
   tags:
-    - k8s-docker
+    - k8s
 
 
 include:


### PR DESCRIPTION
We've been in the process of deprecating the k8s-docker runner for a while. Its replacement is the cloud runner, but in this case, the non-privileged/non-DinD k8s runner would suffice.